### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions-updater.yml
+++ b/.github/workflows/actions-updater.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
       

--- a/.github/workflows/automations.yml
+++ b/.github/workflows/automations.yml
@@ -16,7 +16,7 @@ jobs:
       modified: ${{ steps.check-debs.outputs.modified }}
     steps:
       - name: 📂 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 2
       - name: 📄 Checking for modified debs
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📂 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -81,7 +81,7 @@ jobs:
           git commit -m "[Bot] Update Packages & Release files" || true
         # Add '|| true' to avoid marking as error an empty commit
       - name: 🌐 Push
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
@@ -91,7 +91,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: 📂 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -116,7 +116,7 @@ jobs:
           git commit -m "[Bot] Update minified files" || true
         # Add '|| true' to avoid marking as error an empty commit
       - name: 🌐 Push
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[ad-m/github-push-action](https://github.com/ad-m/github-push-action)** published a new release [v0.6.0](https://github.com/ad-m/github-push-action/releases/tag/v0.6.0) on 2020-05-26T20:53:18Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v3.0.2](https://github.com/actions/checkout/releases/tag/v3.0.2) on 2022-04-21T14:56:58Z
