### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/actions-updater.yml
+++ b/.github/workflows/actions-updater.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: 📂 Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.2
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
       

--- a/.github/workflows/automations.yml
+++ b/.github/workflows/automations.yml
@@ -16,7 +16,7 @@ jobs:
       modified: ${{ steps.check-debs.outputs.modified }}
     steps:
       - name: 📂 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 2
       - name: 📄 Checking for modified debs
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📂 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -91,7 +91,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: 📂 Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
         with:
           persist-credentials: false
           fetch-depth: 0


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release [v3.0.2](https://github.com/actions/checkout/releases/tag/v3.0.2) on 2022-04-21T14:56:58Z
